### PR TITLE
Add dependency list and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Talos
+
+This repository contains code for various experiments with speech recognition, OpenAI integration, and graphics using Pygame.
+
+## Setup
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run any of the example scripts in `InfoPanel/` or the tests under `tests/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pygame
+openai
+boto3
+pyaudio
+SpeechRecognition
+pytest


### PR DESCRIPTION
## Summary
- add `requirements.txt` for common dependencies
- document install step in new README

## Testing
- `pip install -r requirements.txt` *(fails: subprocess-exited-with-error: pyaudio)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68409371301c8330aa4fa408097149fa