### PR TITLE
Fixes water_plants function to use dynamic topics (Fixes #10)

### DIFF
--- a/InfoPanel/main.py
+++ b/InfoPanel/main.py
@@ -119,8 +119,8 @@ def water_plants(pot_number):
     BROKER        = "192.168.1.160"
     PORT          = 1883
     TOPIC_PREFIX  = "quad_pump"
-    topic         = f"{TOPIC_PREFIX}/19"
-    message       = "1"
+    topic         = f"{TOPIC_PREFIX}/{pot_number}"
+    message       = b"1"
 
     client = mqtt.Client()
     client.connect(BROKER, PORT, keepalive=60)


### PR DESCRIPTION
This PR closes Issue #10.

The water_plants function was sending to a hardcoded MQTT topic (.../19) and ignoring the pot_number argument it received. This prevented it from controlling the other pumps.

What was done:

The function now uses the pot_number to dynamically create the MQTT topic (e.g., quad_pump/{pot_number}).

The message was changed from a string ("1") to bytes (b"1") for robustness and to match what the receiver (Peripherals/quad_pump/main.py) expects.